### PR TITLE
Fix export script for macOS/linux

### DIFF
--- a/ExportPNGonSave.lua
+++ b/ExportPNGonSave.lua
@@ -53,14 +53,14 @@ function pt(t)
 end
 
 
---	Gets last occurrence of 'char' in "string"
+--	Gets last occurrence of 'pattern' in "string"
 --[[EXAMPLE
 	s='my.string.here.'
 	print(findlast(s,"%."))
 	print(findlast(s,"e")
 ]]--
-function findlast(str, chr)
-    local i=str:match(".*"..chr.."()")
+function findlast(str, pattern)
+    local i=str:match(".*"..pattern.."()")
     if i==nil then return nil else return i-1 end
 end
 
@@ -69,7 +69,7 @@ end
 function namestrip()
 	local spr = app.activeSprite
 	local path = spr.filename
-	local i1 = findlast(path, '\\') + 1
+	local i1 = findlast(path, '[\\/]') + 1
 	local i2 = findlast(path, '%.') - 1
 	local name = path:sub(i1, i2)
 	return name
@@ -79,7 +79,7 @@ end
 function pathstrip()
 	local spr = app.activeSprite
 	local path = spr.filename
-	local i1 = findlast(path, '\\')
+	local i1 = findlast(path, '[\\/]')
 	local name = path:sub(0, i1)
 	return name
 end


### PR DESCRIPTION
I realize these haven't been updated in 5 years, but this script does exactly what I wanted, except it assumed Windows style paths with backward slashes `\` and thus didn't work for me. 